### PR TITLE
Export logarte_dashboard_screen.dart and disableDebugConsoleLogs

### DIFF
--- a/lib/logarte.dart
+++ b/lib/logarte.dart
@@ -5,5 +5,5 @@ export 'src/models/logarte_entry.dart';
 export 'src/channels/logarte_navigator_observer.dart';
 export 'src/channels/logarte_dio_interceptor.dart';
 export 'src/console/logarte_magical_tap.dart';
-export 'src/console/logarte_magical_tap.dart';
 export 'src/console/logarte_dashboard_screen.dart';
+export 'src/logger/level.dart';

--- a/lib/logarte.dart
+++ b/lib/logarte.dart
@@ -5,3 +5,5 @@ export 'src/models/logarte_entry.dart';
 export 'src/channels/logarte_navigator_observer.dart';
 export 'src/channels/logarte_dio_interceptor.dart';
 export 'src/console/logarte_magical_tap.dart';
+export 'src/console/logarte_magical_tap.dart';
+export 'src/console/logarte_dashboard_screen.dart';

--- a/lib/src/console/logarte_dashboard_screen.dart
+++ b/lib/src/console/logarte_dashboard_screen.dart
@@ -5,10 +5,10 @@ import 'package:logarte/src/console/logarte_theme_wrapper.dart';
 
 class LogarteDashboardScreen extends StatefulWidget {
   final Logarte instance;
-
+  final bool showBackButton;
   const LogarteDashboardScreen(
     this.instance, {
-    Key? key,
+    Key? key, this.showBackButton = false
   }) : super(key: key);
 
   @override
@@ -43,17 +43,24 @@ class _LogarteDashboardScreenState extends State<LogarteDashboardScreen> {
                   floating: true,
                   snap: true,
                   automaticallyImplyLeading: false,
-                  title: TextField(
-                    controller: _controller,
-                    decoration: InputDecoration(
-                      hintText: 'Search',
-                      filled: true,
-                      prefixIcon: const Icon(Icons.search),
-                      suffixIcon: IconButton(
-                        icon: const Icon(Icons.clear),
-                        onPressed: _controller.clear,
+                  title: Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.max,
+                    children: [
+                      if (widget.showBackButton)... [const BackButton()],
+                      TextField(
+                        controller: _controller,
+                        decoration: InputDecoration(
+                          hintText: 'Search',
+                          filled: true,
+                          prefixIcon: const Icon(Icons.search),
+                          suffixIcon: IconButton(
+                            icon: const Icon(Icons.clear),
+                            onPressed: _controller.clear,
+                          ),
+                        ),
                       ),
-                    ),
+                    ],
                   ),
                   bottom: TabBar(
                     isScrollable: true,

--- a/lib/src/console/logarte_dashboard_screen.dart
+++ b/lib/src/console/logarte_dashboard_screen.dart
@@ -42,25 +42,19 @@ class _LogarteDashboardScreenState extends State<LogarteDashboardScreen> {
                 SliverAppBar(
                   floating: true,
                   snap: true,
+                  leading: widget.showBackButton ? const BackButton() : null,
                   automaticallyImplyLeading: false,
-                  title: Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.max,
-                    children: [
-                      if (widget.showBackButton)... [const BackButton()],
-                      TextField(
-                        controller: _controller,
-                        decoration: InputDecoration(
-                          hintText: 'Search',
-                          filled: true,
-                          prefixIcon: const Icon(Icons.search),
-                          suffixIcon: IconButton(
-                            icon: const Icon(Icons.clear),
-                            onPressed: _controller.clear,
-                          ),
-                        ),
+                  title: TextField(
+                    controller: _controller,
+                    decoration: InputDecoration(
+                      hintText: 'Search',
+                      filled: true,
+                      prefixIcon: const Icon(Icons.search),
+                      suffixIcon: IconButton(
+                        icon: const Icon(Icons.clear),
+                        onPressed: _controller.clear,
                       ),
-                    ],
+                    ),
                   ),
                   bottom: TabBar(
                     isScrollable: true,

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -4,6 +4,7 @@ import 'package:logarte/src/console/logarte_auth_screen.dart';
 import 'package:logarte/src/console/logarte_overlay.dart';
 import 'package:logarte/src/extensions/object_extensions.dart';
 import 'package:logarte/src/extensions/route_extensions.dart';
+import 'package:logarte/src/extensions/trace_extensions.dart';
 import 'package:logarte/src/logger/logger.dart';
 import 'package:logarte/src/logger/outputs/memory_output.dart';
 import 'package:logarte/src/logger/printers/pretty_printer.dart';
@@ -69,6 +70,7 @@ class Logarte {
     Object? message, {
     bool write = true,
     Trace? trace,
+        String? source,
   }) {
     // TODO: try and catch
     if (!disableDebugConsoleLogs){
@@ -82,7 +84,7 @@ class Logarte {
       _add(
         PlainLogarteEntry(
           message.toString(),
-          trace: trace ?? Trace.current(),
+          source: source ?? (trace ?? Trace.current()).source,
         ),
       );
     }

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -55,13 +55,14 @@ class Logarte {
     Object? message, {
     bool write = true,
     Trace? trace,
-    Level level = Level.info,
+    Level level = Level.info, String? source,
   }) {
     _log(
       level,
       message,
       write: write,
       trace: trace ?? Trace.current(),
+        source: source
     );
   }
 

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -66,7 +66,7 @@ class Logarte {
     
     
 
-    if (write && !disableDebugConsoleLogs) {
+    if (write) {
       _add(
         PlainLogarteEntry(
           message.toString(),

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -59,15 +59,14 @@ class Logarte {
   }) {
     // TODO: try and catch
 
-    if (!disableDebugConsoleLogs){
-      _logger.log(
-        level,
-        message.toString(),
-      );
-    }
+    _logger.log(
+      level,
+      message.toString(),
+    );
+    
     
 
-    if (write) {
+    if (write && !disableDebugConsoleLogs) {
       _add(
         PlainLogarteEntry(
           message.toString(),

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -17,6 +17,7 @@ class Logarte {
   final bool ignorePassword;
   final bool disableDebugConsoleLogs;
   final Function(String data)? onShare;
+  final int logBufferLength;
   final Function(BuildContext context)? onRocketLongPressed;
   final Function(BuildContext context)? onRocketDoubleTapped;
   late final Logger _logger;
@@ -28,6 +29,7 @@ class Logarte {
     this.onRocketLongPressed,
     this.onRocketDoubleTapped,
     this.disableDebugConsoleLogs = kReleaseMode,
+    this.logBufferLength = 2500,
   }) {
     _logger = Logger(
       output:  disableDebugConsoleLogs ? MemoryOutput(bufferSize: 1) : null,
@@ -40,7 +42,13 @@ class Logarte {
   }
 
   final logs = ValueNotifier(<LogarteEntry>[]);
-  void _add(LogarteEntry entry) => logs.value = [...logs.value, entry];
+  void _add(LogarteEntry entry) {
+    //Drop the oldest log entry to prevent ram bloat
+    if (logs.value.length > logBufferLength){
+      logs.value.removeAt(0);
+    }
+    logs.value = [...logs.value, entry];
+  }
 
   void info(
     Object? message, {

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -42,9 +42,10 @@ class Logarte {
     Object? message, {
     bool write = true,
     Trace? trace,
+    Level level = Level.info,
   }) {
     _log(
-      Level.info,
+      level,
       message,
       write: write,
       trace: trace ?? Trace.current(),

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -5,6 +5,7 @@ import 'package:logarte/src/console/logarte_overlay.dart';
 import 'package:logarte/src/extensions/object_extensions.dart';
 import 'package:logarte/src/extensions/route_extensions.dart';
 import 'package:logarte/src/logger/logger.dart';
+import 'package:logarte/src/logger/outputs/memory_output.dart';
 import 'package:logarte/src/logger/printers/pretty_printer.dart';
 import 'package:logarte/src/models/logarte_entry.dart';
 import 'package:logarte/src/models/navigation_action.dart';
@@ -29,14 +30,13 @@ class Logarte {
     this.disableDebugConsoleLogs = kReleaseMode,
   }) {
     _logger = Logger(
+      output:  disableDebugConsoleLogs ? MemoryOutput(bufferSize: 1) : null,
+      level: disableDebugConsoleLogs? Level.off : Level.trace,
       printer: PrettyPrinter(
         lineLength: 100,
         methodCount: 0,
       ),
     );
-    if (disableDebugConsoleLogs){
-      Logger.level = Level.off;
-    }
   }
 
   final logs = ValueNotifier(<LogarteEntry>[]);
@@ -63,14 +63,12 @@ class Logarte {
     Trace? trace,
   }) {
     // TODO: try and catch
-    _logger.log(
-      level,
-      message.toString(),
-    );
-
-
-    
-    
+    if (!disableDebugConsoleLogs){
+      _logger.log(
+        level,
+        message.toString(),
+      );
+    }
 
     if (write) {
       _add(

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -34,6 +34,9 @@ class Logarte {
         methodCount: 0,
       ),
     );
+    if (disableDebugConsoleLogs){
+      Logger.level = Level.off;
+    }
   }
 
   final logs = ValueNotifier(<LogarteEntry>[]);
@@ -60,12 +63,11 @@ class Logarte {
     Trace? trace,
   }) {
     // TODO: try and catch
-    if (!disableDebugConsoleLogs){
-      _logger.log(
-        level,
-        message.toString(),
-      );
-    }
+    _logger.log(
+      level,
+      message.toString(),
+    );
+
 
     
     

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -58,11 +58,13 @@ class Logarte {
     Trace? trace,
   }) {
     // TODO: try and catch
+    if (!disableDebugConsoleLogs){
+      _logger.log(
+        level,
+        message.toString(),
+      );
+    }
 
-    _logger.log(
-      level,
-      message.toString(),
-    );
     
     
 

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -59,7 +59,7 @@ class Logarte {
   }) {
     // TODO: try and catch
 
-    if (disableDebugConsoleLogs){
+    if (!disableDebugConsoleLogs){
       _logger.log(
         level,
         message.toString(),

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -9,6 +9,7 @@ import 'package:logarte/src/logger/printers/pretty_printer.dart';
 import 'package:logarte/src/models/logarte_entry.dart';
 import 'package:logarte/src/models/navigation_action.dart';
 import 'package:stack_trace/stack_trace.dart';
+import 'package:logarte/src/logger/level.dart';
 
 class Logarte {
   final String? password;

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -13,6 +13,7 @@ import 'package:stack_trace/stack_trace.dart';
 class Logarte {
   final String? password;
   final bool ignorePassword;
+  final bool disableDebugConsoleLogs;
   final Function(String data)? onShare;
   final Function(BuildContext context)? onRocketLongPressed;
   final Function(BuildContext context)? onRocketDoubleTapped;
@@ -24,6 +25,7 @@ class Logarte {
     this.onShare,
     this.onRocketLongPressed,
     this.onRocketDoubleTapped,
+    this.disableDebugConsoleLogs = kReleaseMode,
   }) {
     _logger = Logger(
       printer: PrettyPrinter(
@@ -57,10 +59,13 @@ class Logarte {
   }) {
     // TODO: try and catch
 
-    _logger.log(
-      level,
-      message.toString(),
-    );
+    if (disableDebugConsoleLogs){
+      _logger.log(
+        level,
+        message.toString(),
+      );
+    }
+    
 
     if (write) {
       _add(

--- a/lib/src/logger/level.dart
+++ b/lib/src/logger/level.dart
@@ -1,0 +1,17 @@
+/// [Level]s to control logging output.
+enum Level {
+  all(0),
+  trace(1000),
+  navigation(1200),
+  network(1500),
+  debug(2000),
+  info(3000),
+  warning(4000),
+  error(5000),
+  fatal(6000),
+  off(10000);
+
+  final int value;
+
+  const Level(this.value);
+}

--- a/lib/src/logger/log_filter.dart
+++ b/lib/src/logger/log_filter.dart
@@ -1,4 +1,5 @@
 import 'package:logarte/src/logger/logger.dart';
+import 'package:logarte/src/logger/level.dart';
 
 /// An abstract filter of log messages.
 ///

--- a/lib/src/logger/logger.dart
+++ b/lib/src/logger/logger.dart
@@ -5,24 +5,9 @@ import 'package:logarte/src/logger/log_output.dart';
 import 'package:logarte/src/logger/log_printer.dart';
 import 'package:logarte/src/logger/outputs/console_output.dart';
 import 'package:logarte/src/logger/printers/pretty_printer.dart';
+import 'package:logarte/src/logger/level.dart';
 
-/// [Level]s to control logging output.
-enum Level {
-  all(0),
-  trace(1000),
-  navigation(1200),
-  network(1500),
-  debug(2000),
-  info(3000),
-  warning(4000),
-  error(5000),
-  fatal(6000),
-  off(10000);
 
-  final int value;
-
-  const Level(this.value);
-}
 
 class LogEvent {
   final Level level;

--- a/lib/src/logger/logger.dart
+++ b/lib/src/logger/logger.dart
@@ -99,7 +99,8 @@ class Logger {
     } else if (level == Level.all) {
       throw ArgumentError('Log events cannot have Level.all');
     } else if (level == Level.off) {
-      throw ArgumentError('Log events cannot have Level.off');
+      //throw ArgumentError('Log events cannot have Level.off');
+      return; // Do nothing if nothing to log
     }
 
     var logEvent = LogEvent(

--- a/lib/src/logger/printers/prefix_printer.dart
+++ b/lib/src/logger/printers/prefix_printer.dart
@@ -1,5 +1,6 @@
 import 'package:logarte/src/logger/log_printer.dart';
 import 'package:logarte/src/logger/logger.dart';
+import 'package:logarte/src/logger/level.dart';
 
 /// A decorator for a [LogPrinter] that allows for the prepending of every
 /// line in the log output with a string for the level of that log. For

--- a/lib/src/logger/printers/pretty_printer.dart
+++ b/lib/src/logger/printers/pretty_printer.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'dart:math';
-
+import 'package:logarte/src/logger/level.dart';
 import 'package:logarte/src/logger/ansi_color.dart';
 import 'package:logarte/src/logger/log_printer.dart';
 import 'package:logarte/src/logger/logger.dart';

--- a/lib/src/logger/printers/simple_printer.dart
+++ b/lib/src/logger/printers/simple_printer.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-
+import 'package:logarte/src/logger/level.dart';
 import 'package:logarte/src/logger/ansi_color.dart';
 import 'package:logarte/src/logger/log_printer.dart';
 import 'package:logarte/src/logger/logger.dart';

--- a/lib/src/models/logarte_entry.dart
+++ b/lib/src/models/logarte_entry.dart
@@ -20,15 +20,13 @@ abstract class LogarteEntry {
 
 class PlainLogarteEntry extends LogarteEntry {
   final String message;
-  final String? _source;
+  final String? source;
 
   PlainLogarteEntry(
     this.message, {
-    required Trace trace,
-  })  : _source = trace.source,
-        super(LogarteType.plain);
+    this.source,
+  })  : super(LogarteType.plain);
 
-  String? get source => _source;
 
   @override
   List<String> get contents => [


### PR DESCRIPTION
I wanted to use go router, and my existing method to lock developer mode settings, So this exports the main dashboard.

also adds `disableDebugConsoleLogs` from #3 
also exports the Level and adds it to info()
also adds an optional back button to the dashboard (off by default)
adds `logBufferLength` to limit the number of stored logs. defaults to 2500. #2 
adds a source value to 'info' logs which overwrites the source from Trace.source

I think this PR may continue to bloat as I make changes for myself