### PR TITLE
Set source directly

### DIFF
--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -41,12 +41,14 @@ class Logarte {
     Object? message, {
     bool write = true,
     Trace? trace,
+    String? source,
   }) {
     _log(
       Level.info,
       message,
       write: write,
       trace: trace ?? Trace.current(),
+        source: source
     );
   }
 
@@ -55,7 +57,7 @@ class Logarte {
     Object? message, {
     bool write = true,
     Trace? trace,
-        String? source,
+    String? source,
   }) {
     // TODO: try and catch
 

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -4,6 +4,7 @@ import 'package:logarte/src/console/logarte_auth_screen.dart';
 import 'package:logarte/src/console/logarte_overlay.dart';
 import 'package:logarte/src/extensions/object_extensions.dart';
 import 'package:logarte/src/extensions/route_extensions.dart';
+import 'package:logarte/src/extensions/trace_extensions.dart';
 import 'package:logarte/src/logger/logger.dart';
 import 'package:logarte/src/logger/printers/pretty_printer.dart';
 import 'package:logarte/src/models/logarte_entry.dart';
@@ -54,6 +55,7 @@ class Logarte {
     Object? message, {
     bool write = true,
     Trace? trace,
+        String? source,
   }) {
     // TODO: try and catch
 
@@ -66,7 +68,7 @@ class Logarte {
       _add(
         PlainLogarteEntry(
           message.toString(),
-          trace: trace ?? Trace.current(),
+          source: source ?? (trace ?? Trace.current()).source,
         ),
       );
     }

--- a/lib/src/models/logarte_entry.dart
+++ b/lib/src/models/logarte_entry.dart
@@ -20,15 +20,13 @@ abstract class LogarteEntry {
 
 class PlainLogarteEntry extends LogarteEntry {
   final String message;
-  final String? _source;
+  final String? source;
 
   PlainLogarteEntry(
     this.message, {
-    required Trace trace,
-  })  : _source = trace.source,
-        super(LogarteType.plain);
+    this.source,
+  })  : super(LogarteType.plain);
 
-  String? get source => _source;
 
   @override
   List<String> get contents => [


### PR DESCRIPTION
Allows setting the log source directly, instead of relying on trace