### PR TITLE
Allow disabling console logs

### DIFF
--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -16,6 +16,7 @@ class Logarte {
   final int logBufferLength;
   final Function(BuildContext context)? onRocketLongPressed;
   final Function(BuildContext context)? onRocketDoubleTapped;
+  final bool disableDebugConsoleLogs;
   final Widget? customTab;
 
   Logarte({
@@ -25,6 +26,7 @@ class Logarte {
     this.onRocketLongPressed,
     this.onRocketDoubleTapped,
     this.logBufferLength = 2500,
+    this.disableDebugConsoleLogs = false,
     this.customTab,
   });
 
@@ -121,11 +123,13 @@ class Logarte {
     String? source,
     StackTrace? stackTrace,
   }) {
-    developer.log(
-      message.toString(),
-      name: 'logarte',
-      stackTrace: stackTrace,
-    );
+    if (!disableDebugConsoleLogs) {
+      developer.log(
+        message.toString(),
+        name: 'logarte',
+        stackTrace: stackTrace,
+      );
+    }
 
     if (write) {
       _add(
@@ -143,8 +147,7 @@ class Logarte {
     required NavigationAction action,
   }) {
     try {
-      if ([route.routeName, previousRoute.routeName]
-          .any((e) => e?.contains('/logarte') == true)) {
+      if ([route.routeName, previousRoute.routeName].any((e) => e?.contains('/logarte') == true)) {
         return;
       }
 


### PR DESCRIPTION
Multiple people asked for disabling console logs and keeping all other features.


In bigger projects this logger generates thousands of lines in the console so it's must to have feature. Please take a look at this 4 lines long PR.