### PR TITLE
bugfix: logarte floating button navigation back issue

### DIFF
--- a/lib/src/console/logarte_auth_screen.dart
+++ b/lib/src/console/logarte_auth_screen.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:logarte/logarte.dart';
+import 'package:logarte/src/console/logarte_fab_state.dart';
 import 'package:logarte/src/console/logarte_theme_wrapper.dart';
 
 T? ambiguate<T>(T? value) => value;
@@ -27,13 +28,16 @@ class _LogarteAuthScreenState extends State<LogarteAuthScreen> {
   @override
   void initState() {
     super.initState();
-
     _controller = TextEditingController();
+    LogarteFabState.instance.open();
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    if (!_isLoggedIn) {
+      LogarteFabState.instance.close();
+    }
     super.dispose();
   }
 
@@ -79,6 +83,7 @@ class _LogarteAuthScreenState extends State<LogarteAuthScreen> {
 
   void _onSubmit() {
     if (widget.instance.password == _controller.text) {
+      _isLoggedIn = true;
       _goToDashboard();
     } else {
       ScaffoldMessenger.of(context).showSnackBar(
@@ -96,7 +101,5 @@ class _LogarteAuthScreenState extends State<LogarteAuthScreen> {
         settings: const RouteSettings(name: '/logarte_dashboard'),
       ),
     );
-
-    _isLoggedIn = true;
   }
 }

--- a/lib/src/console/logarte_dashboard_screen.dart
+++ b/lib/src/console/logarte_dashboard_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:logarte/logarte.dart';
 import 'package:logarte/src/console/logarte_entry_item.dart';
+import 'package:logarte/src/console/logarte_fab_state.dart';
 import 'package:logarte/src/console/logarte_theme_wrapper.dart';
 
 class LogarteDashboardScreen extends StatefulWidget {
@@ -24,11 +25,13 @@ class _LogarteDashboardScreenState extends State<LogarteDashboardScreen> {
   void initState() {
     super.initState();
     _controller = TextEditingController();
+    LogarteFabState.instance.open();
   }
 
   @override
   void dispose() {
     _controller.dispose();
+    LogarteFabState.instance.close();
     super.dispose();
   }
 

--- a/lib/src/console/logarte_fab_state.dart
+++ b/lib/src/console/logarte_fab_state.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/scheduler.dart';
+
+class LogarteFabState {
+  LogarteFabState._internal();
+
+  static final LogarteFabState _instance = LogarteFabState._internal();
+
+  static LogarteFabState get instance => _instance;
+
+  final ValueNotifier<bool> _isOpened = ValueNotifier(false);
+
+  /// Expose as ValueListenable for external listeners
+  ValueListenable<bool> get fabStateListener => _isOpened;
+
+  /// Current state
+  bool get isOpened => _isOpened.value;
+
+  /// Open the FAB (set true)
+  void open() {
+    _deferUpdate(true);
+  }
+
+  /// Close the FAB (set false)
+  void close() {
+    _deferUpdate(false);
+  }
+
+  void _deferUpdate(bool value) {
+    // Safely defer updates after the current frame
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _isOpened.value = value;
+    });
+  }
+}

--- a/lib/src/console/logarte_overlay.dart
+++ b/lib/src/console/logarte_overlay.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:logarte/logarte.dart';
 import 'package:logarte/src/console/logarte_auth_screen.dart';
+import 'package:logarte/src/console/logarte_fab_state.dart';
 
 class LogarteOverlay extends StatelessWidget {
   final Logarte instance;
@@ -163,7 +164,6 @@ class _LogarteFAB extends StatefulWidget {
 }
 
 class _LogarteFABState extends State<_LogarteFAB> {
-  bool _isOpened = false;
 
   @override
   void setState(VoidCallback fn) {
@@ -173,7 +173,7 @@ class _LogarteFABState extends State<_LogarteFAB> {
   Future<void> _onPressed() async {
     if (!widget.onTapAllowed) return;
 
-    if (_isOpened) {
+    if (LogarteFabState.instance.isOpened) {
       Navigator.of(context).pop();
     } else {
       Navigator.of(context).push<void>(
@@ -185,38 +185,41 @@ class _LogarteFABState extends State<_LogarteFAB> {
         ),
       );
     }
-
-    setState(() => _isOpened = !_isOpened);
   }
 
   @override
   Widget build(BuildContext context) {
-    return GestureDetector(
-      onTap: _onPressed,
-      onDoubleTap: () {
-        if (!_isOpened && widget.onTapAllowed) {
-          widget.instance.onRocketDoubleTapped?.call(context);
-        }
+    return ValueListenableBuilder(
+      valueListenable: LogarteFabState.instance.fabStateListener,
+      builder: (_, bool isOpened, Widget? child) {
+        return GestureDetector(
+          onTap: _onPressed,
+          onDoubleTap: () {
+            if (!isOpened && widget.onTapAllowed) {
+              widget.instance.onRocketDoubleTapped?.call(context);
+            }
+          },
+          onLongPress: () {
+            if (!isOpened && widget.onTapAllowed) {
+              widget.instance.onRocketLongPressed?.call(context);
+            }
+          },
+          child: AnimatedContainer(
+            duration: kThemeAnimationDuration,
+            width: 52,
+            height: 52,
+            decoration: BoxDecoration(
+              color: isOpened ? Colors.red : Colors.lightBlue,
+              borderRadius: BorderRadius.circular(16),
+            ),
+            child: Icon(
+              isOpened ? Icons.close : Icons.terminal,
+              size: 28,
+              color: Colors.white,
+            ),
+          ),
+        );
       },
-      onLongPress: () {
-        if (!_isOpened && widget.onTapAllowed) {
-          widget.instance.onRocketLongPressed?.call(context);
-        }
-      },
-      child: AnimatedContainer(
-        duration: kThemeAnimationDuration,
-        width: 52,
-        height: 52,
-        decoration: BoxDecoration(
-          color: _isOpened ? Colors.red : Colors.lightBlue,
-          borderRadius: BorderRadius.circular(16),
-        ),
-        child: Icon(
-          _isOpened ? Icons.close : Icons.terminal,
-          size: 28,
-          color: Colors.white,
-        ),
-      ),
     );
   }
 }


### PR DESCRIPTION
Issue fix #18 

Also, fix the issue where, when you're on the Network Logger Details screen and press the close icon on the floating button, it navigates back to the Dashboard screen, but the floating button changes to a terminal icon. This creates a loop where you can no longer return to your main application.