### PR TITLE
Dynamically show/hide console's back button based on LogarteOverlay attachment status

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -127,6 +127,16 @@ class HomePageState extends State<HomePage> {
                 ),
               ),
             ),
+            ListTile(
+              leading: const Icon(Icons.dashboard_outlined),
+              title: const Text('Logarte console'),
+              subtitle: const Text(
+                'Tap to open the console directly.',
+              ),
+              onTap: () {
+                logarte.openConsole(context);
+              },
+            ),
             const Divider(
               height: 40,
             ),

--- a/lib/src/console/logarte_auth_screen.dart
+++ b/lib/src/console/logarte_auth_screen.dart
@@ -47,7 +47,10 @@ class _LogarteAuthScreenState extends State<LogarteAuthScreen> {
       child: WillPopScope(
         onWillPop: () => Future.value(false),
         child: _isLoggedIn || _noPassword
-            ? LogarteDashboardScreen(widget.instance)
+            ? LogarteDashboardScreen(
+                widget.instance,
+                showBackButton: !widget.instance.isOverlayAttached,
+              )
             : Scaffold(
                 appBar: AppBar(
                   automaticallyImplyLeading: false,
@@ -97,7 +100,10 @@ class _LogarteAuthScreenState extends State<LogarteAuthScreen> {
   void _goToDashboard() {
     Navigator.of(context).pushReplacement(
       MaterialPageRoute(
-        builder: (_) => LogarteDashboardScreen(widget.instance),
+        builder: (_) => LogarteDashboardScreen(
+          widget.instance,
+          showBackButton: !widget.instance.isOverlayAttached,
+        ),
         settings: const RouteSettings(name: '/logarte_dashboard'),
       ),
     );

--- a/lib/src/console/logarte_dashboard_screen.dart
+++ b/lib/src/console/logarte_dashboard_screen.dart
@@ -47,7 +47,14 @@ class _LogarteDashboardScreenState extends State<LogarteDashboardScreen> {
                 SliverAppBar(
                   floating: true,
                   snap: true,
-                  leading: widget.showBackButton ? const BackButton() : null,
+                  leading: widget.showBackButton
+                      ? IconButton(
+                          onPressed: () {
+                            Navigator.of(context).pop();
+                          },
+                          icon: const Icon(Icons.arrow_back_ios_new_rounded),
+                        )
+                      : null,
                   automaticallyImplyLeading: false,
                   title: TextField(
                     controller: _controller,

--- a/lib/src/console/logarte_overlay.dart
+++ b/lib/src/console/logarte_overlay.dart
@@ -11,11 +11,28 @@ class LogarteOverlay extends StatelessWidget {
     Key? key,
   }) : super(key: key);
 
+  // Static tracking mechanism
+  static OverlayEntry? _currentEntry;
+  static bool _isAttached = false;
+
+  /// Check if LogarteOverlay is currently attached
+  static bool get isAttached => _isAttached;
+
+  /// Get the current overlay entry (if attached)
+  static OverlayEntry? get currentEntry => _currentEntry;
+
   static void attach({
     required BuildContext context,
     required Logarte instance,
   }) {
-    final entry = OverlayEntry(
+    // Remove existing overlay if already attached
+    if (_isAttached && _currentEntry != null) {
+      _currentEntry!.remove();
+      _isAttached = false;
+      _currentEntry = null;
+    }
+
+    _currentEntry = OverlayEntry(
       builder: (context) {
         return LogarteOverlay._internal(
           instance: instance,
@@ -25,8 +42,18 @@ class LogarteOverlay extends StatelessWidget {
 
     Future.delayed(kThemeAnimationDuration, () {
       final overlay = Overlay.of(context);
-      overlay.insert(entry);
+      overlay.insert(_currentEntry!);
+      _isAttached = true;
     });
+  }
+
+  /// Detach the current overlay
+  static void detach() {
+    if (_isAttached && _currentEntry != null) {
+      _currentEntry!.remove();
+      _isAttached = false;
+      _currentEntry = null;
+    }
   }
 
   @override
@@ -164,7 +191,6 @@ class _LogarteFAB extends StatefulWidget {
 }
 
 class _LogarteFABState extends State<_LogarteFAB> {
-
   @override
   void setState(VoidCallback fn) {
     if (mounted) super.setState(fn);

--- a/lib/src/logarte.dart
+++ b/lib/src/logarte.dart
@@ -204,6 +204,14 @@ class Logarte {
     }
   }
 
+  /// Check if LogarteOverlay is currently attached
+  bool get isOverlayAttached => LogarteOverlay.isAttached;
+
+  /// Detach the LogarteOverlay if it's currently attached
+  void detachOverlay() {
+    LogarteOverlay.detach();
+  }
+
   Future<void> openConsole(BuildContext context) async {
     return Navigator.of(context).push<void>(
       MaterialPageRoute(


### PR DESCRIPTION
Fix for: https://github.com/kamranbekirovyz/logarte/issues/26

- Add a mechanism to check if LogarteOverlay is attached
- Using the mechanism to show or hide the back button
- Change BackButton that uses maybePop() to IconButton with Navigator.pop() for reliable back navigation



https://github.com/user-attachments/assets/8e7e5242-49cc-48c9-a98d-674be55a09d8

