### PR TITLE
Export NavigationAction to allow calling Logarte.navigation method

### DIFF
--- a/lib/logarte.dart
+++ b/lib/logarte.dart
@@ -6,3 +6,4 @@ export 'src/channels/logarte_navigator_observer.dart';
 export 'src/channels/logarte_dio_interceptor.dart';
 export 'src/console/logarte_magical_tap.dart';
 export 'src/console/logarte_dashboard_screen.dart';
+export 'src/models/navigation_action.dart';


### PR DESCRIPTION
Allow using `Logarte.navigation` method.
This method's parameter has a `NavigationAction` type, but `NavigationAction` is not exported.
